### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/JSON/Unmarshal.pm
+++ b/lib/JSON/Unmarshal.pm
@@ -1,4 +1,4 @@
-module JSON::Unmarshal;
+unit module JSON::Unmarshal;
 use JSON::Tiny;
 
 sub panic($json, $type) {


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.