### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -32,7 +32,7 @@ my $json = q/
 
 my $p = unmarshal($json, Person);
 
-isa_ok $p, Person;
+isa-ok $p, Person;
 is $p.name, "John Brown";
 is $p.age, 17;
 is $p.dogs.elems, 2;


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants. The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.