### PR TITLE
done -> done-testing

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -44,4 +44,4 @@ is $p.dogs[1].name, 'Panda';
 is $p.dogs[1].race, 'wolfish';
 is $p.dogs[1].age, 13;
 
-done;
+done-testing;


### PR DESCRIPTION
Hi,
all the other tests pass, but the "done" raises the error:

```
done without supply or react
  in block <unit> at t/basic.t:47

t/basic.t .. 
Dubious, test returned 1 (wstat 256, 0x100)
All 10 subtests passed 

Test Summary Report
-------------------
t/basic.t (Wstat: 256 Tests: 10 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
Files=1, Tests=10,  1 wallclock secs ( 0.02 usr  0.00 sys +  1.04 cusr  0.04 csys =  1.10 CPU)
Result: FAIL
```

