### PR TITLE
Add trait to specify custom unmarshalling for an attribute

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,6 @@
 {
     "name"        : "JSON::Unmarshal",
-    "version"     : "0.01",
+    "version"     : "0.02",
     "description" : "Turn JSON into objects",
     "provides"    : {
         "JSON::Unmarshal" : "lib/JSON/Unmarshal.pm"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# JSON::Unmarshal
+
+Make JSON from an Object (the opposite of JSON::Marshal)
+
+## Synopsis
+
+```
+    use JSON::Unmarshal;
+
+    class SomeClass {
+      has Str $.string;
+      has Int $.int;
+    }
+
+	 my $json = '{ "string" : "string", "int" : 42 }';
+
+    my SomeClass $object = unmarshal($json, SomeClass);
+
+	 say $object.string; # -> "string"
+    say $object.int;    # -> 42
+
+```
+
+## Description
+
+This provides a single exported subroutine to create an object from a
+JSON representation of an object.
+
+It only initialises the "public" attributes (that is those with accessors
+created by declaring them with the '.' twigil. Attributes without acccessors
+are ignored.
+
+## Installation
+
+Assuming you have a working perl6 installation you should be able to
+install this with *ufo* :
+
+    ufo
+    make test
+    make install
+
+*ufo* can be installed with *panda* for rakudo:
+
+    panda install ufo
+
+Or you can install directly with "panda":
+
+    # From the source directory
+   
+    panda install .
+
+    # Remote installation
+
+    panda install JSON::Unmarshal
+
+Other install mechanisms may be become available in the future.
+
+## Support
+
+This should be considered experimental software until such time that
+Perl 6 reaches an official release.  However suggestions/patches are
+welcomed via github at
+
+   https://github.com/tadzik/JSON-Unmarshal
+
+## Licence
+
+Please see the LICENCE file in the distribution
+
+(C) Tadeusz Sośnierz 2015

--- a/README.md
+++ b/README.md
@@ -21,6 +21,29 @@ Make JSON from an Object (the opposite of JSON::Marshal)
 
 ```
 
+It is also possible to use a trait to control how the value is unmarshalled:
+
+```
+
+    use JSON::Unmarshal
+
+    class SomeClass {
+        has Version $.version is unmarshalled-by(-> $v { Version.new($v) });
+    }
+
+    my $json = '{ "version" : "0.0.1" }';
+
+    my SomeClass $object = unmarshal($json, SomeClass);
+
+	 say $object.version; # -> "v0.0.1"
+
+```
+
+The trait has two variants, one which takes a Routine as above, the other
+a Str representing the name of a method that will be called on the type
+object of the attribute type (such as "new",) both are expected to take
+the value from the JSON as a single argument.
+
 ## Description
 
 This provides a single exported subroutine to create an object from a

--- a/t/trait.t
+++ b/t/trait.t
@@ -32,5 +32,5 @@ subtest {
     is $obj.version, Version.new("0.0.1"), "and has the right value";
 }, "unmarshalled-by trait with Method name";
 
-
+done-testing;
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/t/trait.t
+++ b/t/trait.t
@@ -1,0 +1,36 @@
+#!perl6
+use v6;
+use Test;
+use JSON::Unmarshal;
+
+subtest {
+    class VersionClassCode {
+        has Version $.version is unmarshalled-by(-> $v { Version.new($v) });
+    }
+
+    my $json = '{ "version" : "0.0.1" }';
+
+    my VersionClassCode $obj;
+
+    lives-ok { $obj = unmarshal($json, VersionClassCode) }, "unmarshall with attrbute strait (code)";
+    isa-ok $obj.version, Version, "the attribute is the right kind of thing";
+    ok $obj.version.defined, "and it's defined";
+    is $obj.version, Version.new("0.0.1"), "and has the right value";
+}, "unmarshalled-by trait with Code";
+subtest {
+    class VersionClassMethod {
+        has Version $.version is unmarshalled-by('new');
+    }
+
+    my $json = '{ "version" : "0.0.1" }';
+
+    my VersionClassMethod $obj;
+
+    lives-ok { $obj = unmarshal($json, VersionClassMethod) }, "unmarshall with attrbute trait (method name)";
+    isa-ok $obj.version, Version, "the attribute is the right kind of thing";
+    ok $obj.version.defined, "and it's defined";
+    is $obj.version, Version.new("0.0.1"), "and has the right value";
+}, "unmarshalled-by trait with Method name";
+
+
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
Hi,
As described on IRC last night, here is a simple implementation of traits that can control how an attribute is unmarshalled.  I've added a README with examples.

I'm going to do a symmetrical change in JSON::Marshal this afternoon.

Hope that helps.