### PR TITLE
Add support for json-name trait in classes

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,10 +1,10 @@
 {
     "name"        : "JSON::Unmarshal",
-    "version"     : "0.02",
+    "version"     : "0.03",
     "description" : "Turn JSON into objects",
     "provides"    : {
         "JSON::Unmarshal" : "lib/JSON/Unmarshal.pm"
     },
-    "depends"     : ["JSON::Tiny"],
+    "depends"     : ["JSON::Tiny", "JSON::Name"],
     "source-url"  : "git://github.com/tadzik/JSON-Unmarshal.git"
 }

--- a/t/json-name.t
+++ b/t/json-name.t
@@ -1,0 +1,24 @@
+#!perl6
+
+use v6;
+use lib 'lib';
+
+use Test;
+
+use JSON::Unmarshal;
+use JSON::Name;
+
+class TestClass {
+    has $.nice-name is rw is json-name('666.evil.name');
+}
+
+my $json = '{ "666.evil.name" : "some value we want" }';
+
+my $obj;
+lives-ok { $obj = unmarshal($json, TestClass) }, "Unmarshal object with a json-name attribute";
+
+
+is $obj.nice-name,"some value we want", "and we got the key back with the json name";
+
+done-testing;
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
As mentioned on IRC here is support for having a json-name on an attribute in a class to be unmarshalled.

It adds the dependency on JSON::Name as the usage is identical in JSON::Marshal, but that is tiny and very simple (with no dependencies of its own.)

Have fun.