### PR TITLE
Slip fix

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
+	 "perl"        : "6",
     "name"        : "JSON::Unmarshal",
-    "version"     : "0.03",
+    "version"     : "0.04",
     "description" : "Turn JSON into objects",
     "provides"    : {
         "JSON::Unmarshal" : "lib/JSON/Unmarshal.pm"

--- a/lib/JSON/Unmarshal.pm
+++ b/lib/JSON/Unmarshal.pm
@@ -68,6 +68,9 @@ multi _unmarshal($json, Str) {
     if $json ~~ Stringy {
         return Str($json)
     }
+    else {
+        Str;
+    }
 }
 
 multi _unmarshal($json, Bool) {

--- a/t/types.t
+++ b/t/types.t
@@ -57,6 +57,17 @@ subtest {
     is $ret.bool, True, "and the correct value";
 
 }, "Bool attribute";
+subtest {
+    my class StrClass {
+        has Str $.string;
+    }
+
+    my $json = '{ "string" : null }';
+    my $ret;
+    lives-ok { $ret = unmarshal($json, StrClass) }, "unmarshal with Str type attribute but null in JSON";
+    isa-ok $ret, StrClass, "it's the right type";
+    ok $ret.string ~~ Str && !$ret.string.defined, "and it is an undefined Str";
+}, "Undefined Str";
 
 done-testing;
 


### PR DESCRIPTION
Discovered this with real world data.  A "null" attribute was causing

```
Type check failed in assignment to $!name; expected Str but got Slip
```

Returning a Str type object in this case fixes this.
