### PR TITLE
Add typeconstraint

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,7 +1,7 @@
 {
 	 "perl"        : "6",
     "name"        : "JSON::Unmarshal",
-    "version"     : "0.04",
+    "version"     : "0.05",
     "description" : "Turn JSON into objects",
     "provides"    : {
         "JSON::Unmarshal" : "lib/JSON/Unmarshal.pm"

--- a/lib/JSON/Unmarshal.pm
+++ b/lib/JSON/Unmarshal.pm
@@ -12,7 +12,7 @@ role CustomUnmarshaller {
 role CustomUnmarshallerCode does CustomUnmarshaller {
     has &.unmarshaller is rw;
 
-    method unmarshal($value, $type) {
+    method unmarshal($value, Mu:U $type) {
         # the dot below is important otherwise it refers
         # to the accessor method
         self.unmarshaller.($value);


### PR DESCRIPTION
The custom unmarshal method $type parameter didn't have a type constraint, thus defaulted to Any.
This is a problem if the attribute type is literally Mu (say it's a type or a matcher.)  

