### PR TITLE
Fix for unmarshalling a sub-class

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,7 +1,7 @@
 {
 	 "perl"        : "6",
     "name"        : "JSON::Unmarshal",
-    "version"     : "0.06",
+    "version"     : "0.07",
     "description" : "Turn JSON into objects",
     "provides"    : {
         "JSON::Unmarshal" : "lib/JSON/Unmarshal.pm"

--- a/lib/JSON/Unmarshal.pm
+++ b/lib/JSON/Unmarshal.pm
@@ -84,7 +84,11 @@ multi _unmarshal($json, Bool) {
 
 multi _unmarshal($json, Any $x) {
     my %args;
+    my %local-attrs =  $x.^attributes(:local).map({ $_.name => $_.package });
     for $x.^attributes -> $attr {
+        if %local-attrs{$attr.name}:exists && !(%local-attrs{$attr.name} === $attr.package ) {
+            next;
+        }
         my $attr-name = $attr.name.substr(2);
         my $json-name = do if  $attr ~~ JSON::Name::NamedAttribute {
             $attr.json-name;

--- a/t/trait.t
+++ b/t/trait.t
@@ -32,6 +32,26 @@ subtest {
     is $obj.version, Version.new("0.0.1"), "and has the right value";
 }, "unmarshalled-by trait with Method name";
 subtest {
+    class Inner {
+        has Str $.name is required;
+    }
+    class OuterClass {
+        has Inner $.inner;
+    }
+    class OuterSubClass is OuterClass {
+        has Inner $.inner is unmarshalled-by(-> $name { Inner.new(:$name) });
+    }
+
+    my $json = '{ "inner" : "name" }';
+
+    my OuterSubClass $obj;
+
+    lives-ok { $obj = unmarshal($json, OuterSubClass) }, "unmarshall with attrbute trait on sub-class";
+    isa-ok $obj.inner, Inner, "the attribute is the right kind of thing";
+    ok $obj.inner.defined, "and it's defined";
+    is $obj.inner.name, "name", "and has the right value";
+}, "unmarshalled-by trait with inheritance";
+subtest {
     class CustomArrayAttribute {
         class Inner {
             has Str $.name is required;


### PR DESCRIPTION
Hi,
The ^attributes meta method will return the attributes defined in a parent class, even if they would be masked in the child class by a local definition, normally this only results in the unmarshalling doing some extra work, however if the child class needs to define a customer unmarshaller with a trait then it will do the right thing for the local over-ride but because the parent attribute can't have the trait it will overwrite the already correctly unmarshalled attribute data with the possibly incorrect parent definition.

So what this does is cache the locally defined attributes and then skip the similarly named attributes if they aren't the local ones (by comparing the package of the attribute.)