### PR TITLE
Handle null attribute 

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,7 +1,7 @@
 {
-	 "perl"        : "6",
+	"perl"        : "6.c",
     "name"        : "JSON::Unmarshal",
-    "version"     : "0.07",
+    "version"     : "0.08",
     "description" : "Turn JSON into objects",
     "provides"    : {
         "JSON::Unmarshal" : "lib/JSON/Unmarshal.pm"

--- a/lib/JSON/Unmarshal.pm
+++ b/lib/JSON/Unmarshal.pm
@@ -41,14 +41,18 @@ sub panic($json, $type) {
     die "Cannot unmarshal {$json.perl} to type {$type.perl}"
 }
 
-multi _unmarshal($json, Int) {
+multi _unmarshal(Any:U, Mu $type) {
+    $type;
+}
+
+multi _unmarshal(Any:D $json, Int) {
     if $json ~~ Int {
         return Int($json)
     }
     panic($json, Int)
 }
 
-multi _unmarshal($json, Rat) {
+multi _unmarshal(Any:D $json, Rat) {
    CATCH {
       default {
          panic($json, Rat);
@@ -57,7 +61,7 @@ multi _unmarshal($json, Rat) {
    return Rat($json);
 }
 
-multi _unmarshal($json, Numeric) {
+multi _unmarshal(Any:D $json, Numeric) {
     if $json ~~ Numeric {
         return Num($json)
     }
@@ -73,7 +77,7 @@ multi _unmarshal($json, Str) {
     }
 }
 
-multi _unmarshal($json, Bool) {
+multi _unmarshal(Any:D $json, Bool) {
    CATCH {
       default {
          panic($json, Bool);
@@ -82,7 +86,7 @@ multi _unmarshal($json, Bool) {
    return Bool($json);
 }
 
-multi _unmarshal($json, Any $x) {
+multi _unmarshal(Any:D $json, Any $x) {
     my %args;
     my %local-attrs =  $x.^attributes(:local).map({ $_.name => $_.package });
     for $x.^attributes -> $attr {
@@ -126,7 +130,7 @@ multi _unmarshal($json, %x) {
    return %ret;
 }
 
-multi _unmarshal($json, Mu) {
+multi _unmarshal(Any:D $json, Mu) {
     return $json
 }
 

--- a/t/null.t
+++ b/t/null.t
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl6
+
+use v6.*;
+
+use Test;
+use JSON::Unmarshal;
+
+my Str $json = '{ "attr" : null }';
+
+my @tests = %( "class" => class  { has Int $.attr; }, description => "Int attribute" ),
+            %( "class" => class  { has Num $.attr; }, description => "Num attribute" ),
+            %( "class" => class  { has Rat $.attr; }, description => "Rat attribute" ),
+            %( "class" => class  { has Str $.attr; }, description => "Str attribute" ),;
+
+for @tests -> $test {
+    my $obj;
+    lives-ok { $obj = unmarshal($json, $test<class> ) }, $test<description>;
+}
+
+done-testing;
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
The case where the JSON attribute is null only worked for a Str target attribute.  This fixes for all handled types.

It passes all the existing tests.